### PR TITLE
Add NexTool to Utilities section

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ This is a curated list about tools for everything from productivity to hosting t
 - FreeFileSync - https://freefilesync.org/
 - CryptoMator - https://cryptomator.org/
 - WinScp - https://winscp.net
+- NexTool (228+ free browser-based developer tools) - https://nextool.app/free-tools/
 - Putty - http://www.putty.org/
 
 ### Testing and Code Insights


### PR DESCRIPTION
## What is NexTool?

[NexTool](https://nextool.app/free-tools/) is a collection of 228+ free browser-based developer tools including JSON formatter, Base64 encoder/decoder, regex tester, color converter, UUID generator, hash generators, and more.

## Why add it?

- **Free** — All 228+ tools are completely free, no signup required
- **Browser-based** — Runs entirely in the browser, no installation needed
- **Developer-focused** — Tools cover encoding, formatting, generating, converting, and other common dev tasks
- **Perfect for startups** — Eliminates the need to install or pay for multiple utility tools

Added to the **Utilities** section alongside similar tools.