### PR TITLE
Add Frontman to AI-based Code Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ This is a curated list about tools for everything from productivity to hosting t
 - Qodo - https://www.qodo.ai
 - TabNine - https://www.tabnine.com
 - Cline - https://cline.bot
-- Frontman - https://frontman.dev
+- Frontman - https://frontman.sh
 
 ### Development Playgrounds
 - JSFiddle - https://jsfiddle.net

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ This is a curated list about tools for everything from productivity to hosting t
 - Qodo - https://www.qodo.ai
 - TabNine - https://www.tabnine.com
 - Cline - https://cline.bot
+- Frontman - https://frontman.dev
 
 ### Development Playgrounds
 - JSFiddle - https://jsfiddle.net


### PR DESCRIPTION
## Summary

- Adds [Frontman](https://frontman.sh) to the **AI-based Code Agents** section
- Follows the existing list format (`- Name - URL`)