### PR TITLE
Add Developer Marketing & Advertising section

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,12 @@ This is a curated list about tools for everything from productivity to hosting t
 - Vidclue - https://vidclue.com/
 - AnswerThePublic - https://answerthepublic.com/
 
+### Developer Marketing & Advertising:
+- daily.dev Ads - https://business.daily.dev - Advertise to 1M+ developers through native feed ads and newsletter sponsorships
+- Carbon Ads - https://www.carbonads.net/ - Developer-focused ad network
+- BuySellAds - https://www.buysellads.com/ - Advertising marketplace for tech audiences
+- EthicalAds - https://www.ethicalads.io/ - Privacy-focused developer advertising
+
 ### Web Experimentation:
 - VWO - https://vwo.com
 - PostHog - https://posthog.com


### PR DESCRIPTION
Adding a new **Developer Marketing & Advertising** subsection under Business, Marketing, Sales, Finance.

Many startups and dev tool companies need to reach developers but there's no section for developer-focused advertising platforms. This adds the main options:

- **daily.dev Ads** - Native feed ads and newsletter sponsorships reaching 1M+ developers
- **Carbon Ads** - Developer-focused ad network
- **BuySellAds** - Advertising marketplace for tech audiences
- **EthicalAds** - Privacy-focused developer advertising

These are commonly used by developer tool companies, SaaS startups, and hiring teams looking to reach software engineers.