### PR TITLE
Add PageGuard to Site Performance Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ This is a curated list about tools for everything from productivity to hosting t
 
 ### Site Performance Tools:
 - Page Gym - https://pagegym.com
+- PageGuard - https://pageguard.org
 - Pingdom http://tools.pingdom.com/fpt	pingdom.com - Website monitor
 - Google Page Insight	https://developers.google.com/speed/pagespeed/insights
 - Web Page Performance Test - http://www.webpagetest.org/


### PR DESCRIPTION
Adding [PageGuard](https://pageguard.org) to the Site Performance Tools section.

PageGuard is a free all-in-one website health scanner that covers:
- SEO audit
- Core Web Vitals & performance
- Accessibility (WCAG 2.1)
- Best practices
- AI-generated action plans
- REST API (no signup required)

Unlike single-purpose tools (GTMetrix for load time, Pingdom for uptime), PageGuard gives founders a complete picture of their site health in one scan — ideal for startups who need comprehensive coverage without multiple paid tools.

https://pageguard.org