### PR TITLE
Add Waitlio to Sales & Marketing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ This is a curated list about tools for everything from productivity to hosting t
 - Website Headlines - https://websiteheadlines.com
 - Vidclue - https://vidclue.com
 - AnswerThePublic - https://answerthepublic.com
+- Waitlio - https://waitlio.com
 
 ### Web Experimentation:
 - VWO - https://vwo.com


### PR DESCRIPTION
## Add Waitlio

[Waitlio](https://waitlio.com) is a waitlist software that lets startups build a branded pre-launch waitlist page in seconds. Collect email subscribers, verify signups automatically, and manage your product launch — no code required.

**Pricing:** Freemium (Free plan: 100 subscribers/month, paid plans from €9/month)

Added to the **Sales & Marketing** section following the existing entry format.