### PR TITLE
Add How Much To Start A Business to Accounting & Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ This is a curated list about tools for everything from productivity to hosting t
 ### Accounting & Finance
 - Wave Apps - https://www.waveapps.com
 - Odoo Accounting - https://www.odoo.com/app/accounting
+- How Much To Start A Business - https://howmuchtostartabusiness.com
 
 ### CRM:
 - HubSpot CRM - https://www.hubspot.com/products/crm


### PR DESCRIPTION
## Summary
- Adds [How Much To Start A Business](https://howmuchtostartabusiness.com) to the **Accounting & Finance** section
- Free startup cost calculator covering 350+ industries with detailed cost breakdowns
- Highly relevant for startups, entrepreneurs, and indie hackers planning their budget

## Details
This tool helps founders estimate startup costs across 350+ industries before launching. It provides detailed breakdowns of one-time and recurring expenses, making it a valuable free resource for anyone starting a business.

Format matches existing entries in the list.