### PR TITLE
Add HeyRobyn - Native Mac unified inbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ This is a curated list about tools for everything from productivity to hosting t
 - Mattermost - https://mattermost.com
 - Rocket.Chat - https://rocket.chat
 - Twist - https://twist.com
+- HeyRobyn - https://heyrobyn.ai - Native Mac unified inbox for email, Slack, and GitHub
 
 ### Customer Support/Live Chat:
 - Zendesk Chat (formerly Zopim) - https://www.zopim.com/


### PR DESCRIPTION
## Addition

**HeyRobyn** - https://heyrobyn.ai - Native Mac unified inbox for email, Slack, and GitHub

## Why this addition makes sense

HeyRobyn fits perfectly in the **Team Chat & Communication** section as a unified inbox that brings together multiple communication channels that startups commonly use:

- **Email** (Gmail, Outlook, etc.)
- **Slack** (team chat)
- **GitHub** (developer notifications)

## Key features relevant for startups

- **Native macOS app** built with SwiftUI (not Electron) - fast and efficient
- **Privacy-first** - all data stored on-device
- **Free tier available** - perfect for startups and indie hackers getting started
- **Productivity focus** - manage all communication channels in one window

This complements the existing tools in the Team Chat & Communication section (Slack, Teams, etc.) by providing a unified inbox solution for managing multiple channels.