### PR TITLE
Add AI Business Assistants section

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ This is a curated list about tools for everything from productivity to hosting t
 - TabNine - https://www.tabnine.com
 - Cline - https://cline.bot
 
+### AI Business Assistants
+- AI Assistant for SMBs - https://openclawapp.netlify.app/assistant/
+
 ### Development Playgrounds
 - JSFiddle - https://jsfiddle.net
 - Plunker - https://plnkr.co/


### PR DESCRIPTION
## Summary
Added new **AI Business Assistants** section to organize business-focused AI tools separate from code-focused tools.

## Changes
- Created new section "### AI Business Assistants"
- Added AI Assistant for SMBs as first entry
- Follows repo format: Name - URL (no description)

## Why
This addresses the format issue from PR #90. The previous PR included a description which was inconsistent with the repo's style guide. This version follows the established "Name - URL" format used throughout the list.

## Positioning
Placed after "AI-based Code Agents" and before "Development Playgrounds" to logically group business automation tools separate from development tools.