### PR TITLE
Add MapAtlas under Maps & Geolocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ This is a curated list about tools for everything from productivity to hosting t
 - ClouDNS - https://cloudns.net/
 - Let's Encrypt - https://letsencrypt.org/
 
+### Maps & Geolocation:
+- MapAtlas - https://mapatlas.eu
+
 ### Site Performance Tools:
 - Page Gym - https://pagegym.com
 - Pingdom https://tools.pingdom.com/fpt	pingdom.com - Website monitor


### PR DESCRIPTION
Adding MapAtlas as a mapping API tool for startups.

MapAtlas provides geocoding, routing, map tiles, and search APIs with a free tier (10k map loads/month). EU-hosted, GDPR compliant.

Website: https://mapatlas.eu

Disclosure: I am affiliated with MapMetrics B.V., the company behind MapAtlas.