### PR TITLE
Add PersonaResearch to Sales & Marketing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ This is a curated list about tools for everything from productivity to hosting t
 - Website Headlines - https://websiteheadlines.com
 - Vidclue - https://vidclue.com
 - AnswerThePublic - https://answerthepublic.com
+- PersonaResearch - https://personaresearch-production.up.railway.app - Turn App Store reviews into customer personas in 2 minutes using AI
 
 ### Web Experimentation:
 - VWO - https://vwo.com


### PR DESCRIPTION
PersonaResearch is a free-tier AI tool that turns App Store reviews into customer personas in under 2 minutes — useful for startups doing customer discovery without a research budget.

- **URL:** https://personaresearch.dev
- **Free tier:** 3 research jobs/month, no credit card needed
- **Category:** Sales & Marketing — customer insights and persona research

Helps indie founders understand their target market using real user reviews instead of expensive research agencies.