### PR TITLE
Add PersonaResearch to Sales & Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ This is a curated list about tools for everything from productivity to hosting t
 - Website Headlines - https://websiteheadlines.com
 - Vidclue - https://vidclue.com
 - AnswerThePublic - https://answerthepublic.com
+- PersonaResearch - https://personaresearch-production.up.railway.app - Turn App Store reviews into customer personas in 2 minutes using AI
 
 ### Web Experimentation:
 - VWO - https://vwo.com

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ This is a curated list about tools for everything from productivity to hosting t
 - Website Headlines - https://websiteheadlines.com
 - Vidclue - https://vidclue.com
 - AnswerThePublic - https://answerthepublic.com
-- PersonaResearch - https://personaresearch.dev - Turn App Store reviews into customer personas in 2 minutes using AI
+- PersonaResearch - https://personaresearch.dev
 
 ### Web Experimentation:
 - VWO - https://vwo.com

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ This is a curated list about tools for everything from productivity to hosting t
 - Website Headlines - https://websiteheadlines.com
 - Vidclue - https://vidclue.com
 - AnswerThePublic - https://answerthepublic.com
-- PersonaResearch - https://personaresearch-production.up.railway.app - Turn App Store reviews into customer personas in 2 minutes using AI
+- PersonaResearch - https://personaresearch.dev - Turn App Store reviews into customer personas in 2 minutes using AI
 
 ### Web Experimentation:
 - VWO - https://vwo.com


### PR DESCRIPTION
Adds [PersonaResearch](https://personaresearch.dev) to the Sales & Marketing section.

Format matches the existing list format: `- Name - URL`