### PR TITLE
Add toprank to Sales & Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ This is a curated list about tools for everything from productivity to hosting t
 - Website Headlines - https://websiteheadlines.com
 - Vidclue - https://vidclue.com
 - AnswerThePublic - https://answerthepublic.com
+- toprank - https://github.com/nowork-studio/toprank (open-source Claude Code plugin — 9 SEO and Google Ads skills; rewrites meta tags, generates JSON-LD schema, and ships fixes to WordPress/Strapi/Contentful/Ghost; MIT, 107 stars)
 
 ### Web Experimentation:
 - VWO - https://vwo.com


### PR DESCRIPTION
Adds **toprank** under Sales & Marketing.

toprank is an open-source (MIT) Claude Code plugin with 9 SEO and Google Ads skills. Connects Google Search Console, PageSpeed Insights, and the Google Ads API, then ships fixes directly — meta tag rewrites, JSON-LD schema markup, keyword bid adjustments, and content pushes to WordPress/Strapi/Contentful/Ghost.

## Traction
- **107 GitHub stars, 14 forks**
- MIT licensed, actively maintained
- CHANGELOG, unit tests, LLM-judge eval tests

- Source: https://github.com/nowork-studio/toprank