### PR TITLE
Add Hiring & Recruitment section

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,12 @@ This is a curated list about tools for everything from productivity to hosting t
 - Google Contacts (can be used as lightweight CRM) - https://contacts.google.com
 - Attio - https://attio.com/
 
+### Hiring & Recruitment
+- AI Dev Jobs - https://aidevboard.com
+- LinkedIn Jobs - https://www.linkedin.com/jobs/
+- Indeed - https://www.indeed.com
+- Wellfound (formerly AngelList Talent) - https://wellfound.com
+
 ### Team Chat & Communication
 - Slack - https://slack.com
 - Microsoft Teams - https://teams.microsoft.com


### PR DESCRIPTION
Add a new **Hiring & Recruitment** section to the list, placed after CRM since they are related business categories.

Includes:
- **AI Dev Jobs** (aidevboard.com) — Job board focused on AI/ML engineering roles with 6,100+ positions
- **LinkedIn Jobs** — The industry standard
- **Indeed** — General job search
- **Wellfound** — Startup-focused hiring (formerly AngelList Talent)

This fills a gap in the list — startups need hiring tools and there was no dedicated section for them.