### PR TITLE
Add Scrupp to Web Scraping Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ This is a curated list about tools for everything from productivity to hosting t
 - Web Scraper - https://chrome.google.com/webstore/detail/web-scraper/jnhgnonknehpejjnehehllkliplmbmhn
 - Scraping API - https://www.abstractapi.com/web-scraping-api
 - Browserbase - https://www.browserbase.com/
+- Scrupp - https://scrupp.com/
 
 ### Development IDEs/Editors (including AI-based)
 - Microsoft Visual Studio Code (VSCode) - https://code.visualstudio.com


### PR DESCRIPTION
Adds [Scrupp](https://scrupp.com/) to the **Web Scraping Tools** section.

Scrupp is a Chrome extension for LinkedIn and Sales Navigator scraping. It exports lead lists with verified work emails and phone numbers, using a multi-provider waterfall for enrichment. Free tier available, pay-per-lead pricing on paid plans — no subscription required.

Fits alongside the other scraping entries in the section (Web Scraper, Scraping Hub, Browserbase). Custom domain (scrupp.com) as per repo guidelines.