### PR TITLE
Add AuditWidget to Sales & Marketing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ This is a curated list about tools for everything from productivity to hosting t
 - Website Headlines - https://websiteheadlines.com
 - Vidclue - https://vidclue.com
 - AnswerThePublic - https://answerthepublic.com
-- AuditWidget - https://auditwidget.app/?utm_source=awesome-startup-tools-list&utm_medium=github - Embeddable SEO audit widget for agency sites; captures visitor emails as leads. White-label ready, free plan available.
+- AuditWidget - https://auditwidget.app/?utm_source=github&utm_medium=awesome_list&utm_campaign=awesome-startup-tools-list - Embeddable SEO audit widget for agency sites; captures visitor emails as leads. White-label ready, free plan available.
 
 ### Web Experimentation:
 - VWO - https://vwo.com

--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ This is a curated list about tools for everything from productivity to hosting t
 - Website Headlines - https://websiteheadlines.com
 - Vidclue - https://vidclue.com
 - AnswerThePublic - https://answerthepublic.com
+- AuditWidget - https://auditwidget.app/?utm_source=awesome-startup-tools-list&utm_medium=github - Embeddable SEO audit widget for agency sites; captures visitor emails as leads. White-label ready, free plan available.
 
 ### Web Experimentation:
 - VWO - https://vwo.com


### PR DESCRIPTION
Adding AuditWidget (https://auditwidget.app) to the Sales & Marketing section.

AuditWidget is a SaaS tool that lets marketing agencies embed a branded SEO audit on their website with a single script tag. The audit captures visitor emails via a gated full-report mechanic — making it both a lead generation tool and an SEO utility. Free plan available, no credit card needed.

Disclosure: I am the creator of AuditWidget.