### PR TITLE
Add Remove Audio — free browser tool to strip audio from videos (no account needed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Awesome list of FREE tools Startups should be using
 This is a curated list about tools for everything from productivity to hosting to development tools to designing. These tools are all digital i.e. either app, online service, or downloadable software. Most of them are either free or have limited free option that is enough for startups, indie hackers, entrepreneurs, individuals, or anyone to get started. Feel free to suggest and contribute in this list. 
 
-> **📢 For Contributors — Please Read Before Submitting a PR**
+> **ð¢ For Contributors â Please Read Before Submitting a PR**
 >
 > This list receives a high volume of tool recommendations. To keep
 > quality high, submissions are now held to a strict editorial standard.
@@ -9,7 +9,7 @@ This is a curated list about tools for everything from productivity to hosting t
 > custom domain.** GitHub repo links, Netlify/Vercel/platform subdomains,
 > and newly launched tools with no track record are rejected automatically.
 >
-> The list is also undergoing a quality cleanup — some older entries that
+> The list is also undergoing a quality cleanup â some older entries that
 > no longer meet the bar are being removed.
 
 ## Tech
@@ -130,6 +130,7 @@ This is a curated list about tools for everything from productivity to hosting t
 - Local (for WordPress) - https://localwp.com
 
 ### Utilities:
+- [Remove Audio](https://remove-audio.com) - Free browser-based tool to remove audio from video files. No sign-up, no uploads, batch up to 20 clips. WebAssembly-powered.
 - FileZilla - https://filezilla-project.org/
 - FreeFileSync - https://freefilesync.org/
 - CryptoMator - https://cryptomator.org/
@@ -390,7 +391,7 @@ Good for team projects
 - Photoshop Express - https://www.photoshop.com/tools
 - Pixlr - https://pixlr.com/
 - Fotor - https://www.fotor.com/
-- Create GIF - https://gifbrewery.com/
+- Create GIF -Â https://gifbrewery.com/
 - Stamp creator - https://www.speedystamps.co.uk/
 - Method Draw (SVG Editor) - https://editor.method.ac
 - AConvert (Image to SVG Converter) - https://www.aconvert.com/image/png-to-svg/


### PR DESCRIPTION
A useful free utility for startups: [Remove Audio](https://remove-audio.com) removes audio from video files entirely in the browser. No account, no uploads, no watermarks. Useful for social media teams, content creators, and anyone who needs muted video clips quickly.

- Free, no account required
- Batch up to 20 files at once
- Works on mobile (iPhone + Android)
- WebAssembly-powered, no server