### PR TITLE
Add AI Invoice Maker to Accounting & Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ This is a curated list about tools for everything from productivity to hosting t
 ### Accounting & Finance
 - Wave Apps - https://www.waveapps.com
 - Odoo Accounting - https://www.odoo.com/app/accounting
+- AI Invoice Maker (free invoice generator with AI payment reminders, no signup) - https://ainvoicemaker.com
 
 ### CRM:
 - HubSpot CRM - https://www.hubspot.com/products/crm


### PR DESCRIPTION
Adds [AI Invoice Maker](https://ainvoicemaker.com) under **Accounting & Finance** alongside Wave Apps and Odoo Accounting.

### Why it fits
- Same category as the existing Wave Apps / Odoo Accounting entries (cloud invoicing/accounting tools for startups & small businesses)
- Free with no signup required — useful for startups evaluating tools without a trial flow
- AI-assisted payment reminders is a feature angle not covered in the current Accounting & Finance entries

### Entry
- AI Invoice Maker (free invoice generator with AI payment reminders, no signup) - https://ainvoicemaker.com

Happy to revise wording or move section if a different placement fits better.