### PR TITLE
Add SalesLabel to Sales & Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ This is a curated list about tools for everything from productivity to hosting t
 - Website Headlines - https://websiteheadlines.com
 - Vidclue - https://vidclue.com
 - AnswerThePublic - https://answerthepublic.com
+- SalesLabel - https://sales-label.com
 
 ### Web Experimentation:
 - VWO - https://vwo.com


### PR DESCRIPTION
Hi @Ibexoft, thanks for maintaining this list. I noticed your contributor notice — quality over quantity, custom domain, established track record. SalesLabel meets both criteria, so I wanted to make sure to provide context up front rather than just drop a link.

I'd like to propose adding **SalesLabel** to the **Sales & Marketing** subsection. SalesLabel is a white-label outbound sales infrastructure platform for B2B agencies. We help 100+ agencies launch their own outbound offers under their own brand, with average results of 42% reply rates and \$180K in pipeline per agency client. The product has been live and in production with paying customers for some time — not a newly launched tool.

- Custom domain: https://sales-label.com (no platform subdomain)
- Established usage: 100+ agencies running production outbound through it
- Free public tool included: https://sales-label.com/tools/margin-calculator (open margin calculator other agency operators can use to estimate their own outbound profitability)

Format used follows the section convention: \`- Name - URL\`.

Happy to provide further verification or revise as needed, and thanks for considering!