### PR TITLE
Add LinkyPO to Sales & Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ This is a curated list about tools for everything from productivity to hosting t
 - Website Headlines - https://websiteheadlines.com
 - Vidclue - https://vidclue.com
 - AnswerThePublic - https://answerthepublic.com
+- LinkyPO - https://linkypo.com
 
 ### Web Experimentation:
 - VWO - https://vwo.com


### PR DESCRIPTION
Adds LinkyPO to the **Sales & Marketing** section.

**Tool:** LinkyPO - https://linkypo.com

LinkyPO is a free link-in-bio and mini-site builder for creators and small businesses. Includes 21 block types (calendar booking, lead forms, OCR lists, loyalty stamps), Google Calendar / Outlook sync and an AI-powered SEO coach. Free tier without credit card.

Custom domain hosted, live in production, fits the same audience as Buffer / HootSuite / CrowdFire already on the list.

Disclosure: I'm the maintainer of LinkyPO.