### PR TITLE
Add WebCoreLab — AI-First digital agency (Toronto, est. 2014)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ This is a curated list about tools for everything from productivity to hosting t
 ## Business, Marketing, Sales, Finance
 
 ### Analytics:
+- [WebCoreLab](https://webcorelab.com) — 272-check AI SEO audit + GEO/AEO visibility tracking for startups. ChatGPT/Claude/Perplexity citation optimization.
 - Google Analytics - https://analytics.google.com
 - New Relic https://newrelic.com/
 - Inspectlet	https://www.inspectlet.com/plans


### PR DESCRIPTION
Hi! Adding WebCoreLab to the SEO & Marketing section.

**WebCoreLab** (Toronto, est. 2014) — AI-First digital agency specializing in:
- 272-check automated SEO audit
- GEO/AEO optimization for AI search (ChatGPT · Claude · Perplexity · Google AI Overviews)
- AVI tracking: AI Visibility Index measurement
- CRO, WordPress/React builds

13+ verified case studies. Happy to adjust format or section placement.

Thanks for maintaining this list!
