### PR TITLE
Add The SEO Autopilot to Sales & Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ This is a curated list about tools for everything from productivity to hosting t
 - Vidclue - https://vidclue.com
 - AnswerThePublic - https://answerthepublic.com
 
+- The SEO Autopilot - https://the-seo-autopilot.com
+
 ### Web Experimentation:
 - VWO - https://vwo.com
 - PostHog - https://posthog.com


### PR DESCRIPTION
Hi! Adds [The SEO Autopilot](https://the-seo-autopilot.com) to the **Sales & Marketing** subsection of Tech.

It's an autonomous AI-agent SEO platform aimed at indie founders and small startups: keyword research, fact-checked drafting, schema, internal linking, scheduling — all autonomous. The site also ships 13 free in-browser SEO tools (llms.txt generator, JSON-LD schema generator, SERP CTR calculator, hreflang/canonical/robots tag generators, AI overview checker, AI content cost calculator) at https://the-seo-autopilot.com/en/free-tools/.

Followed the existing `- Name - URL` format used in this section (bare URL, no markdown link). Happy to adjust if you'd prefer a different style or category.