### PR TITLE
Add Beton Inspector to Sales & Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ This is a curated list about tools for everything from productivity to hosting t
 - Visual Website Optimizer - https://visualwebsiteoptimizer.com
 - Tweriod - https://www.tweriod.com
 - My Site Auditor - https://mysiteauditor.com
-- Beton Inspector (open-source revenue intelligence; scores leads from product + CRM signals, self-hostable) - https://github.com/getbeton/inspector
+- Beton Inspector (open-source revenue intelligence; scores leads from product + CRM signals, self-hostable) - https://getbeton.ai
 - WooBox - https://woobox.com
 - Add Shoppers - https://addshoppers.com
 - BuzzSumo - https://buzzsumo.com

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ This is a curated list about tools for everything from productivity to hosting t
 - Visual Website Optimizer - https://visualwebsiteoptimizer.com
 - Tweriod - https://www.tweriod.com
 - My Site Auditor - https://mysiteauditor.com
+- Beton Inspector (open-source revenue intelligence; scores leads from product + CRM signals, self-hostable) - https://github.com/getbeton/inspector
 - WooBox - https://woobox.com
 - Add Shoppers - https://addshoppers.com
 - BuzzSumo - https://buzzsumo.com


### PR DESCRIPTION
Adding [Beton Inspector](https://github.com/getbeton/inspector) under **Business, Marketing, Sales, Finance → Sales & Marketing** — open-source revenue intelligence that scores leads from product-usage + CRM signals and routes the warmest to reps. Self-hostable. A tool worth knowing for early sales/RevOps teams.