### PR TITLE
Add Flowly under Attendance & Time Tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ Good for team projects
 - Paymo - https://www.paymoapp.com
 - Jibble - https://www.jibble.io
 - Connecteam - https://connecteam.com/employee-time-clock-app/employee-time-tracking-app/
+- Flowly - https://flowly.run (built for solo freelancers; tracks time, links it to clients, and sends invoices from the same workspace)
 
 ## Productivity Techniques
 - Pomodoro Technique - https://en.wikipedia.org/wiki/Pomodoro_Technique


### PR DESCRIPTION
Adding **Flowly** (https://flowly.run) to **Attendance & Time Tracking**.

## What it is
Flowly is a time tracker + invoicing tool built specifically for solo freelancers. It tracks time per client/project and lets you send an invoice from the same workspace in one click. Free tier covers up to 20 tasks and 3 projects; paid tier is \$15/month for the full bundle (time + invoicing).

## Why it fits this section
The current entries in this section (Toggl, Clockify, TimeCamp, Everhour, Paymo, Jibble, Connecteam) skew toward teams and HR/attendance. Flowly is the solo-freelancer counterpart: no team analytics, no admin permissions, no per-member billing rates, but task management and invoicing in the same workspace as the timer.

It's a non-affiliate listing maintained by a solo developer (me, the freelancer building it). Happy to move it to a different section if you'd prefer it under Project/Task Management instead, since it does both.

## Format check
- One-line entry under the existing section
- No new heading
- No reordering of existing entries
- No formatting changes elsewhere