### PR TITLE
Add crawlgraph to Sales & Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ This is a curated list about tools for everything from productivity to hosting t
 - HootSuite - https://hootsuite.com
 - CrowdFire - https://www.crowdfireapp.com
 - Ubersuggest - https://ubersuggest.org
+- crawlgraph - https://crawlgraph.com (free backlink intelligence using the public Common Crawl web graph; $99 lifetime, no monthly)
 - Visual Website Optimizer - https://visualwebsiteoptimizer.com
 - Tweriod - https://www.tweriod.com
 - My Site Auditor - https://mysiteauditor.com


### PR DESCRIPTION
## What

Adds [crawlgraph](https://crawlgraph.com/) to **Tech > Sales & Marketing**, right after Ubersuggest.

## Why it fits

The Sales & Marketing list already includes Ubersuggest, BuzzSumo, AnswerThePublic, and other SEO-adjacent tools that startups use for keyword research and link analysis. crawlgraph fills a small gap there: a free-tier backlink lookup tool with a one-time lifetime price (vs the monthly model that dominates the category).

- **What it does:** Paste any domain → see every public site linking to it. CSV/JSON export.
- **Data source:** Public [Common Crawl](https://commoncrawl.org) hyperlink graph (4.4B edges, 120M domains, quarterly refresh).
- **Pricing:** 5 free queries with no signup; $99 lifetime for unlimited use.
- **Best for:** Outreach prospecting at indie/startup scale where Ahrefs ($129/mo) isn't budgeted.

It's a quarterly snapshot — not a replacement for Ahrefs on live signal monitoring — but for one-off prospecting it fits the indie-startup cost profile this list optimizes for.

## Disclosure

I'm the maintainer of crawlgraph. Happy to revise the entry or move it. Thanks for the list!