### PR TITLE
Add SmartBizCalc to Calculators section (Business/Finance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,9 @@ This is a curated list about tools for everything from productivity to hosting t
 - Wave Apps - https://www.waveapps.com
 - Odoo Accounting - https://www.odoo.com/app/accounting
 
+### Calculators
+- SmartBizCalc - https://smartbizcalc.com - Free business calculators for small businesses and startups (taxes, pricing, break-even, contractor rates, 85+ tools)
+
 ### CRM:
 - HubSpot CRM - https://www.hubspot.com/products/crm
 - Capsule CRM - https://capsulecrm.com


### PR DESCRIPTION
SmartBizCalc (https://smartbizcalc.com) is a free collection of 85+ business calculators for small business owners and founders.

Covers:
- Tax calculators (self-employment tax, 1099 vs W-2, LLC vs S-Corp, quarterly tax)
- Pricing tools (contractor markup, HVAC profit margin, plumbing/electrician rates, freelancer hourly rate)
- Business planning (break-even point, startup cost, food cost, payroll tax)

No sign-up, no paywalls. Custom domain, live and indexed.

I added a new Calculators subsection under Business, Marketing, Sales, Finance.