### PR TITLE
Add Business Formation & Legal section — LLC Class for Wyoming LLC registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,9 @@ This is a curated list about tools for everything from productivity to hosting t
 - Microsoft Clarity - https://clarity.microsoft.com
 - PostHog - https://posthog.com/
 
+### Business Formation & Legal
+- LLC Class - https://llcclass.com (Wyoming LLC registration for non-US founders; covers registered agent for LLC, EIN, and Operating Agreement)
+
 ### Accounting & Finance
 - Wave Apps - https://www.waveapps.com
 - Odoo Accounting - https://www.odoo.com/app/accounting


### PR DESCRIPTION
## What this adds

A new **Business Formation & Legal** subsection under Business, Marketing, Sales, Finance, with:

- **LLC Class** (https://llcclass.com) — Wyoming LLC registration service for non-US founders; covers registered agent for LLC, EIN application, and Operating Agreement templates

## Why this fits

Many startup founders — especially non-US residents building products for the global market — need to form a US LLC before they can open a US bank account, use Stripe, or sell on Amazon/Shopify. This is a foundational step that comes before accounting tools, CRM, and banking.

LLC Class is established (live service, custom domain, active user base) and specifically targets the indie hacker/startup audience that uses this list.

## Placement

Added as a new subsection **before** Accounting & Finance inside the Business, Marketing, Sales, Finance section, since business formation logically precedes accounting setup.