### PR TITLE
Add PDF Toolbox — free browser-based PDF toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ This is a curated list about tools for everything from productivity to hosting t
 - CryptoMator - https://cryptomator.org/
 - WinScp - https://winscp.net
 - Putty - https://www.putty.org/
+- [PDF Toolbox](https://pdftoolbox-three.vercel.app) - Free browser-based PDF tools. Compress, merge, split, convert — all processing done locally, no file uploads.
 
 ### Testing and Code Insights
 - Sauce Labs - https://saucelabs.com/


### PR DESCRIPTION
Add [PDF Toolbox](https://pdftoolbox-three.vercel.app) to Utilities section.

- Free online PDF tools: compress, merge, split, PDF↔JPG, PDF→Word, unlock, protect
- All processing done in-browser via WebAssembly — no file uploads
- No registration, no daily limits
- Useful for startups needing quick document processing without paying for Acrobat